### PR TITLE
Lookup bean in spring context before default construction

### DIFF
--- a/src/main/kotlin/au/kilemon/mockall/MockAllExecutionListener.kt
+++ b/src/main/kotlin/au/kilemon/mockall/MockAllExecutionListener.kt
@@ -266,7 +266,6 @@ class MockAllExecutionListener : TestExecutionListener, Ordered
 
     private fun <T : Any> getExistingBean(kClass: KClass<T>): T?
     {
-        // TODO: This will not qualify the specific bean if there are multiple available in the context
         return try
         {
             testContext.applicationContext.getBean(kClass.java)

--- a/src/main/kotlin/au/kilemon/mockall/MockAllExecutionListener.kt
+++ b/src/main/kotlin/au/kilemon/mockall/MockAllExecutionListener.kt
@@ -3,6 +3,7 @@ package au.kilemon.mockall
 import jakarta.annotation.Resource
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.Ordered
 import org.springframework.test.context.TestContext
 import org.springframework.test.context.TestExecutionListener
@@ -144,7 +145,8 @@ class MockAllExecutionListener : TestExecutionListener, Ordered
                 {
                     spyKClasses.addAll(notMocked.spyClasses.asList())
 
-                    ReflectionUtils.setField(field, createOrGetInstance(currentClazz), createActualOrSpy(field.type.kotlin))
+                    val qualifier = field.getAnnotation(Qualifier::class.java)
+                    ReflectionUtils.setField(field, createOrGetInstance(currentClazz), createActualOrSpy(field.type.kotlin, qualifier))
                     mockAnnotationFields(field.type)
                 }
                 else
@@ -168,7 +170,7 @@ class MockAllExecutionListener : TestExecutionListener, Ordered
      * @param kClass the incoming class that we should create an instance or [Mockito.spy] of
      * @return the constructed [Mockito.spy] OR instance of [T]
      */
-    fun <T : Any> createActualOrSpy(kClass: KClass<T>): T
+    fun <T : Any> createActualOrSpy(kClass: KClass<T>, qualifier: Qualifier? = null): T
     {
         val shouldSpyNotMocked = spyKClasses.contains(kClass)
         return if (shouldSpyNotMocked)
@@ -177,7 +179,20 @@ class MockAllExecutionListener : TestExecutionListener, Ordered
         }
         else
         {
-            findZeroArgConstructor(kClass.java).newInstance()
+            var instance = if (qualifier != null)
+            {
+                getBeanByName(qualifier.value, kClass)
+            }
+            else
+            {
+                getExistingBean(kClass)
+            }
+
+            if (instance == null)
+            {
+                instance = findZeroArgConstructor(kClass.java).newInstance()
+            }
+            instance!!
         }
     }
 
@@ -247,5 +262,30 @@ class MockAllExecutionListener : TestExecutionListener, Ordered
     fun injectableAnnotations(): List<Class<out Annotation>>
     {
         return listOf(Autowired::class.java, Resource::class.java, javax.annotation.Resource::class.java)
+    }
+
+    private fun <T : Any> getExistingBean(kClass: KClass<T>): T?
+    {
+        // TODO: This will not qualify the specific bean if there are multiple available in the context
+        return try
+        {
+            testContext.applicationContext.getBean(kClass.java)
+        }
+        catch (ex: Exception)
+        {
+            null
+        }
+    }
+
+    private fun <T : Any> getBeanByName(name: String, kClass: KClass<T>): T?
+    {
+        return try
+        {
+            testContext.applicationContext.getBean(name, kClass.java)
+        }
+        catch (ex: Exception)
+        {
+            null
+        }
     }
 }

--- a/src/main/kotlin/au/kilemon/mockall/NotMocked.kt
+++ b/src/main/kotlin/au/kilemon/mockall/NotMocked.kt
@@ -12,4 +12,4 @@ import kotlin.reflect.KClass
 @Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-annotation class NotMocked(val spyClasses: Array<KClass<*>>)
+annotation class NotMocked(val spyClasses: Array<KClass<*>> = [])

--- a/src/test/kotlin/au/kilemon/mockall/MockAllExecutionListenerTest.kt
+++ b/src/test/kotlin/au/kilemon/mockall/MockAllExecutionListenerTest.kt
@@ -6,10 +6,7 @@ import au.kilemon.mockall.models.ChildChildClass
 import au.kilemon.mockall.models.NotMockedSpy
 import au.kilemon.mockall.models.ab.AbstractBaseClass
 import au.kilemon.mockall.models.ab.AbstractChildClass
-import au.kilemon.mockall.tests.AbstractTest
-import au.kilemon.mockall.tests.BaseTest
-import au.kilemon.mockall.tests.ChildChildTest
-import au.kilemon.mockall.tests.ChildTest
+import au.kilemon.mockall.tests.*
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -25,7 +22,7 @@ import javax.annotation.Resource
  *
  * @author github.com/Kilemonn
  */
-class TestMockAllExecutionListener
+class MockAllExecutionListenerTest
 {
     /**
      * Setup before each method.
@@ -43,7 +40,7 @@ class TestMockAllExecutionListener
     @Test
     fun testPrepareTestInstance_onBaseClass()
     {
-        MockAllExecutionListener().prepareTestInstance(initialiseContextWithInstance(BaseTest()))
+        MockAllExecutionListener().prepareTestInstance(initialiseContextWithInstance(BaseClassTest()))
 
         val baseClass = MockAllExecutionListener.getInstance(BaseClass::class.java)
         Assertions.assertNotNull(baseClass)
@@ -62,7 +59,7 @@ class TestMockAllExecutionListener
     @Test
     fun testPrepareTestInstance_onChildClass()
     {
-        MockAllExecutionListener().prepareTestInstance(initialiseContextWithInstance(ChildTest()))
+        MockAllExecutionListener().prepareTestInstance(initialiseContextWithInstance(ChildClassTest()))
 
         Assertions.assertNull(MockAllExecutionListener.getInstance(BaseClass::class.java))
 
@@ -308,7 +305,7 @@ class TestMockAllExecutionListener
     @Test
     fun testPrepareTestInstance_onAbstractChildClass()
     {
-        MockAllExecutionListener().prepareTestInstance(initialiseContextWithInstance(AbstractTest()))
+        MockAllExecutionListener().prepareTestInstance(initialiseContextWithInstance(AbstractClassTest()))
 
         val childClass = MockAllExecutionListener.getInstance(AbstractChildClass::class.java)
         Assertions.assertNotNull(childClass)
@@ -336,7 +333,7 @@ class TestMockAllExecutionListener
     fun testNotMocked()
     {
         val listener = MockAllExecutionListener()
-        listener.prepareTestInstance(initialiseContextWithInstance(ChildChildTest()))
+        listener.prepareTestInstance(initialiseContextWithInstance(ChildChildClassTest()))
 
         Assertions.assertNotNull(MockAllExecutionListener.getInstance(ChildChildClass::class.java))
 
@@ -360,8 +357,11 @@ class TestMockAllExecutionListener
         listener.prepareTestInstance(initialiseContextWithInstance(notMockedSpy))
 
         Assertions.assertNotNull(MockAllExecutionListener.getInstance(NotMockedSpy::class.java))
-        Assertions.assertNotNull(MockAllExecutionListener.getInstance(Properties::class.java))
-        Assertions.assertTrue(isSpy(MockAllExecutionListener.getInstance(Properties::class.java)!!))
+
+        val properties = MockAllExecutionListener.getInstance(Properties::class.java)
+        Assertions.assertNotNull(properties)
+        Assertions.assertTrue(isSpy(properties!!))
+
         Assertions.assertNotNull(notMockedSpy.properties)
         Assertions.assertTrue(isSpy(notMockedSpy.properties))
     }

--- a/src/test/kotlin/au/kilemon/mockall/tests/AbstractClassTest.kt
+++ b/src/test/kotlin/au/kilemon/mockall/tests/AbstractClassTest.kt
@@ -4,11 +4,11 @@ import au.kilemon.mockall.models.ab.AbstractChildClass
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
- * Test class used for scenarios in [au.kilemon.mockall.TestMockAllExecutionListener].
+ * Test class used for scenarios in [au.kilemon.mockall.MockAllExecutionListenerTest].
  *
  * @author github.com/Kilemonn
  */
-class AbstractTest
+class AbstractClassTest
 {
     @Autowired
     private lateinit var childClass: AbstractChildClass

--- a/src/test/kotlin/au/kilemon/mockall/tests/BaseClassTest.kt
+++ b/src/test/kotlin/au/kilemon/mockall/tests/BaseClassTest.kt
@@ -4,11 +4,11 @@ import au.kilemon.mockall.models.BaseClass
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
- * Test class used for scenarios in [au.kilemon.mockall.TestMockAllExecutionListener].
+ * Test class used for scenarios in [au.kilemon.mockall.MockAllExecutionListenerTest].
  *
  * @author github.com/Kilemonn
  */
-class BaseTest
+class BaseClassTest
 {
     @Autowired
     private lateinit var baseClass: BaseClass

--- a/src/test/kotlin/au/kilemon/mockall/tests/ChildChildClassTest.kt
+++ b/src/test/kotlin/au/kilemon/mockall/tests/ChildChildClassTest.kt
@@ -4,11 +4,11 @@ import au.kilemon.mockall.models.ChildChildClass
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
- * Test class used for scenarios in [au.kilemon.mockall.TestMockAllExecutionListener].
+ * Test class used for scenarios in [au.kilemon.mockall.MockAllExecutionListenerTest].
  *
  * @author github.com/Kilemonn
  */
-class ChildChildTest
+class ChildChildClassTest
 {
     @Autowired
     private lateinit var childChild: ChildChildClass

--- a/src/test/kotlin/au/kilemon/mockall/tests/ChildClassTest.kt
+++ b/src/test/kotlin/au/kilemon/mockall/tests/ChildClassTest.kt
@@ -4,11 +4,11 @@ import au.kilemon.mockall.models.ChildClass
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
- * Test class used for scenarios in [au.kilemon.mockall.TestMockAllExecutionListener].
+ * Test class used for scenarios in [au.kilemon.mockall.MockAllExecutionListenerTest].
  *
  * @author github.com/Kilemonn
  */
-class ChildTest
+class ChildClassTest
 {
     @Autowired
     private lateinit var childClass: ChildClass

--- a/src/test/kotlin/au/kilemon/mockall/tests/WithContextTest.kt
+++ b/src/test/kotlin/au/kilemon/mockall/tests/WithContextTest.kt
@@ -1,0 +1,101 @@
+package au.kilemon.mockall.tests
+
+import au.kilemon.mockall.MockAllExecutionListener
+import au.kilemon.mockall.NotMocked
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestExecutionListeners
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.util.Properties
+
+/**
+ * A test class demonstrating [au.kilemon.mockall.MockAllExecutionListener] is able to look up and load
+ * existing beans for member variables marked as [au.kilemon.mockall.NotMocked].
+ *
+ * @author github.com/Kilemonn
+ */
+@ExtendWith(SpringExtension::class)
+@TestExecutionListeners(MockAllExecutionListener::class)
+@ContextConfiguration(classes = [WithContextTest.WithContextTestConfiguration::class])
+class WithContextTest
+{
+    companion object
+    {
+        const val PROPERTY_NAME = "Property_name"
+        const val PROPERTY_VALUE = "myV4Lu3"
+    }
+
+    @Autowired
+    @NotMocked
+    private lateinit var map: HashMap<String, String>
+
+    @Qualifier("myProperties")
+    @Autowired
+    @NotMocked
+    private lateinit var properties: Properties
+
+    @Autowired
+    private lateinit var packages: Package
+
+    /**
+     * A Spring configuration that is used for this test class.
+     *
+     * @author github.com/Kilemonn
+     */
+    @TestConfiguration
+    internal open class WithContextTestConfiguration
+    {
+        // The bean lookup by type automatically handles the "Primary" annotation.
+        @Bean
+        @Primary
+        open fun getMap(): HashMap<String, String>
+        {
+            val map = HashMap<String, String>()
+            map[PROPERTY_NAME] = PROPERTY_VALUE
+            return map
+        }
+
+        @Bean
+        open fun anotherMap(): HashMap<String, String>
+        {
+            return HashMap<String, String>()
+        }
+
+        @Bean
+        open fun myProperties(): Properties
+        {
+            val props = Properties()
+            props.setProperty(PROPERTY_NAME, PROPERTY_VALUE)
+            return props
+        }
+    }
+
+    /**
+     * Ensure that creating this test configuration will check and wire in existing beans created in the [TestConfiguration]
+     * before creating zero arg constructor objects.
+     */
+    @Test
+    fun testBeanCreationAndWiring()
+    {
+        Assertions.assertNotNull(map)
+        Assertions.assertFalse(Mockito.mockingDetails(map).isMock)
+        var value = map[PROPERTY_NAME]
+        Assertions.assertEquals(PROPERTY_VALUE, value)
+
+        Assertions.assertNotNull(properties)
+        Assertions.assertFalse(Mockito.mockingDetails(properties).isMock)
+        value = properties.getProperty(PROPERTY_NAME)
+        Assertions.assertEquals(PROPERTY_VALUE, value)
+
+        Assertions.assertNotNull(packages)
+        Assertions.assertTrue(Mockito.mockingDetails(packages).isMock)
+    }
+}


### PR DESCRIPTION
To better honour any beans and test configurations that are being used. The resolution will use existing initialised spring beans in the context if a bean of the exact type exists.

Added support for @Qualifier and @Primary for duplicate bean type look up. 